### PR TITLE
Update EventProviderAbstract.java

### DIFF
--- a/cpt/src/main/java/org/isisaddons/wicket/fullcalendar2/cpt/ui/EventProviderAbstract.java
+++ b/cpt/src/main/java/org/isisaddons/wicket/fullcalendar2/cpt/ui/EventProviderAbstract.java
@@ -70,7 +70,7 @@ public abstract class EventProviderAbstract implements EventProvider {
                         CalendarableDereferencingService.class);
         for (final CalendarableDereferencingService dereferencingService : calendarableDereferencingServices) {
             final Object dereferencedObject = dereferencingService.dereference(domainObject);
-            if(dereferencedObject != domainObject) {
+            if(dereferencedObject != null && dereferencedObject != domainObject) {
                 return dereferencedObject;
             }
         }


### PR DESCRIPTION
I found when using the Incode Notes module, that does have a CalendarableDereferencingService implemented, that the display of other non-note CalendarEventable domain objects is broken. This change fixes the problem.
